### PR TITLE
Yield rows in PdoStatementReader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ foreach ($iterator as $row) {
 ```
 
 The downside of using `yield` is that the reader is no longer countable and when invoking `count()` on such a reader
-a `\LogicException` will be thrown.
+a `\RuntimeException` will be thrown.
 
 
 Change Log

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ $reader->getIterator(); // -> \ArrayIterator
 $reader->count();
 ```
 
+The default behavior shown in the example above is that `getIterator()` will call `fetchAll()` on the `PDOStatement`
+and returns the result in the form of an `\ArrayIterator`. However, if the result set is very large and memory becomes
+a concern it is possible to fetch the result set row by row and yield each row to the workflow. You can invoke the
+behaviour by setting the option `yield` to `true`.
+
+In the following example `getIterator()` returns a `\Generator`.
+
+```php
+use Plum\PlumPdo\PdoStatementReader;
+
+$statement = $pdo->prepare('SELECT * FROM users WHERE age >= :min_age');
+$statement->bindValue(':min_age', 18);
+$statement->execute();
+
+$reader = new PdoStatementReader($statement, [’yield' => true]);
+$iterator = $reader->getIterator(); // -> \Generator
+foreach ($iterator as $row) {
+}
+```
+
+The downside of using `yield` is that the reader is no longer countable and when invoking `count()` on such a reader
+a `\LogicException` will be thrown.
+
 
 Change Log
 ----------

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     }
   ],
   "require": {
+    "php": ">=5.5",
     "plumphp/plum": "~0.2"
   },
   "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
         </whitelist>
     </filter>
 
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+    <listeners>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
+    </listeners>
 </phpunit>

--- a/src/PdoStatementReader.php
+++ b/src/PdoStatementReader.php
@@ -16,6 +16,7 @@ use LogicException;
 use PDO;
 use PDOStatement;
 use Plum\Plum\Reader\ReaderInterface;
+use RuntimeException;
 
 /**
  * PdoStatementReader
@@ -67,12 +68,12 @@ class PdoStatementReader implements ReaderInterface
     /**
      * @return int
      *
-     * @throws LogicException if the `yield` option is set to `true`.
+     * @throws RuntimeException if the `yield` option is set to `true`.
      */
     public function count()
     {
         if ($this->options['yield']) {
-            throw new LogicException('Could not count \PDOStatement because "yield" option is set to true. If '.
+            throw new RuntimeException('Could not count \PDOStatement because "yield" option is set to true. If '.
                                      'the reader should be countable please set the option "yield" to false.');
         }
 

--- a/src/PdoStatementReader.php
+++ b/src/PdoStatementReader.php
@@ -66,6 +66,8 @@ class PdoStatementReader implements ReaderInterface
 
     /**
      * @return int
+     *
+     * @throws LogicException if the `yield` option is set to `true`.
      */
     public function count()
     {

--- a/tests/PdoStatementReaderTest.php
+++ b/tests/PdoStatementReaderTest.php
@@ -174,9 +174,9 @@ class PdoStatementReaderTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Plum\PlumPdo\PdoStatementReader::count()
-     * @expectedException \LogicException
+     * @expectedException \RuntimeException
      */
-    public function countThrowsLogicExceptionIfYieldOptionIsSetToTrue()
+    public function countThrowsRuntimeExceptionIfYieldOptionIsSetToTrue()
     {
         /** @var \PDOStatement $statement */
         $statement = Mockery::mock('\PDOStatement');


### PR DESCRIPTION
Instead of using `PDOStatement::fetchAll()` and creating an `ArrayIterator` for the returned data `PdoStatementReader` now uses `PDOStatement::fetch()` to fetch each row individually and yield them to the caller. Thus, it would be possible to create a pipeline where an item is read, convert, filtered, written, etc before the next item is read.

However, I had to implement a hack, because the yield concept does not work with `count()`. Therefore, if `count()` is called the result is fetched using `fetchAll()`. If `getIterator()` is called afterwards the rows are yielded from a cached array. And to make `count()` work after `getIterator()` has been called the rows returned by `fetch()` are cached and `count()` returns the data based on the cache. Either way, data is fetched from the database only once.

Fixes #2 
